### PR TITLE
Add whisper-cli transcription option

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -13,3 +13,4 @@ build/
 *.egg-info/
 *.wav
 transcripts/
+ggml-large-v3-turbo.bin

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # Video to Text Converter
 
-A simple utility that extracts audio tracks from video files, sends them to AssemblyAI for transcription, and saves the resulting text alongside each source video.
+A simple utility that extracts audio tracks from video files and transcribes them using either AssemblyAI API or whisper-cli, saving the resulting text alongside each source video.
 
 ## Installation
 
@@ -22,7 +22,21 @@ sudo apt install ffmpeg
 # Download from https://ffmpeg.org/download.html
 ```
 
-3. Provide your AssemblyAI API key using one of the following methods:
+3. Choose your transcription method:
+
+### Option A: Using whisper-cli (Recommended)
+1. Install whisper-cli:
+```bash
+# macOS
+brew install whisper-cli
+
+# Or build from source: https://github.com/ggerganov/whisper.cpp
+```
+
+2. Download a whisper model (e.g., ggml-large-v3-turbo.bin) and place it in the project directory.
+
+### Option B: Using AssemblyAI API
+1. Provide your AssemblyAI API key using one of the following methods:
 ```bash
 # Preferred: environment variable
 export ASSEMBLYAI_API_KEY="your_api_key_here"
@@ -35,6 +49,8 @@ export ASSEMBLYAI_API_KEY="your_api_key_here"
 All settings live in `config.toml`:
 
 - `video.paths` — list of absolute or relative paths to the video files to process
+- `transcription.method` — choose between "whisper" or "assemblyai"
+- `whisper` — whisper-cli related options (model path, language, threads, etc.)
 - `assemblyai` — AssemblyAI related options (API key, speech model, language, formatting)
 - `audio` — audio extraction parameters (sample rate, channels, codec)
 
@@ -46,6 +62,26 @@ paths = [
     "/path/to/video1.mp4",
     "/path/to/video2.mp4"
 ]
+
+[transcription]
+# Method: "whisper" or "assemblyai"
+method = "whisper"
+
+[whisper]
+# Path to the whisper model file
+model_path = "ggml-large-v3-turbo.bin"
+# Language code (e.g., "ru", "en", "auto")
+language = "ru"
+# Number of threads
+threads = 16
+# Suppress non-speech tokens
+suppress_nst = true
+# Max context
+max_context = 128
+# No prompt
+no_prompt = true
+# Best of N
+best_of = 7
 
 [assemblyai]
 # Leave blank to rely on ASSEMBLYAI_API_KEY
@@ -63,9 +99,9 @@ codec = "pcm_s16le"
 
 ## Usage
 
-1. Obtain an API key from [AssemblyAI](https://www.assemblyai.com/).
-2. Update `config.toml` with video paths and any preferred transcription options.
-3. Export `ASSEMBLYAI_API_KEY` (or set the key in the config file).
+1. Update `config.toml` with video paths and your preferred transcription method.
+2. If using AssemblyAI, obtain an API key from [AssemblyAI](https://www.assemblyai.com/) and set it as an environment variable or in the config file.
+3. If using whisper-cli, ensure the model file is in the project directory.
 4. Run the script:
 ```bash
 python main.py
@@ -75,7 +111,7 @@ python main.py
 
 1. Loads configuration from `config.toml`.
 2. Extracts audio from each video file to WAV (16 kHz, mono).
-3. Sends the audio to AssemblyAI for transcription.
+3. Transcribes the audio using the selected method (whisper-cli or AssemblyAI).
 4. Saves the transcript to a `.txt` file next to the source video.
 5. Removes temporary audio files once transcription completes.
 

--- a/config.toml
+++ b/config.toml
@@ -19,3 +19,27 @@ format_text = true
 sample_rate = 16000
 channels = 1
 codec = "pcm_s16le"
+
+# Whisper CLI settings
+[whisper]
+# Path to the whisper model file
+model_path = "ggml-large-v3-turbo.bin"
+# Language code (e.g., "ru", "en", "auto")
+language = "auto"
+# Number of threads
+threads = 16
+# Suppress non-speech tokens
+suppress_nst = true
+# Max context
+max_context = 128
+# No prompt
+no_prompt = true
+# Best of N
+best_of = 7
+# Enable/disable whisper transcription
+enabled = true
+
+# Transcription method selection
+[transcription]
+# Method: "assemblyai" or "whisper"
+method = "whisper"

--- a/main.py
+++ b/main.py
@@ -57,6 +57,67 @@ def extract_audio_from_video(video_path, output_audio_path, config):
         return False
 
 
+def transcribe_audio_whisper(audio_path, config):
+    """Transcribe an audio file using whisper-cli."""
+    whisper_config = config.get("whisper", {})
+    
+    print(f"      Whisper model: {whisper_config.get('model_path', 'ggml-large-v3-turbo.bin')}")
+    print(f"      Language: {whisper_config.get('language', 'ru')}")
+    print(f"      Threads: {whisper_config.get('threads', 16)}")
+    print(f"      Max context: {whisper_config.get('max_context', 128)}")
+    print(f"      Best of: {whisper_config.get('best_of', 7)}")
+    
+    try:
+        # Build whisper-cli command
+        cmd = [
+            "whisper-cli",
+            "-m", whisper_config.get("model_path", "ggml-large-v3-turbo.bin"),
+            audio_path,
+            "--output-txt",
+            "-l", whisper_config.get("language", "ru"),
+            "-t", str(whisper_config.get("threads", 16)),
+            "-mc", str(whisper_config.get("max_context", 128)),
+            "--best-of", str(whisper_config.get("best_of", 7))
+        ]
+        
+        # Add optional flags
+        if whisper_config.get("suppress_nst", True):
+            cmd.append("--suppress-nst")
+        if whisper_config.get("no_prompt", True):
+            cmd.append("-np")
+        
+        print(f"      Running command: {' '.join(cmd)}")
+        
+        result = subprocess.run(cmd, capture_output=True, text=True, cwd=os.getcwd())
+        
+        if result.returncode != 0:
+            print(f"      Whisper-cli error: {result.stderr}")
+            return None
+        
+        # The output file should be audio_path + ".txt"
+        output_txt_path = audio_path + ".txt"
+        
+        if not os.path.exists(output_txt_path):
+            print(f"      Output file not found: {output_txt_path}")
+            return None
+        
+        # Read the transcribed text
+        with open(output_txt_path, "r", encoding="utf-8") as file:
+            text_content = file.read().strip()
+        
+        print("      Whisper transcription completed successfully.")
+        print(f"      Transcript length: {len(text_content)} characters")
+        
+        # Clean up the temporary output file
+        os.remove(output_txt_path)
+        
+        return {"text": text_content, "status": "completed"}
+        
+    except Exception as exc:
+        print(f"      Error during whisper transcription: {exc}")
+        return None
+
+
 def transcribe_audio(audio_path, api_key, config):
     """Transcribe an audio file using the AssemblyAI API."""
     assemblyai_config = config.get("assemblyai", {})
@@ -107,6 +168,30 @@ def transcribe_audio(audio_path, api_key, config):
         return None
 
 
+def check_whisper_requirements(config):
+    """Check if whisper-cli and model are available."""
+    whisper_config = config.get("whisper", {})
+    model_path = whisper_config.get("model_path", "ggml-large-v3-turbo.bin")
+    
+    # Check if whisper-cli is available
+    try:
+        result = subprocess.run(["whisper-cli", "--help"], capture_output=True, text=True)
+        if result.returncode != 0:
+            print("Warning: whisper-cli not found or not working properly.")
+            return False
+    except FileNotFoundError:
+        print("Warning: whisper-cli not found in PATH.")
+        return False
+    
+    # Check if model file exists
+    if not os.path.exists(model_path):
+        print(f"Warning: Whisper model file not found: {model_path}")
+        return False
+    
+    print(f"Whisper-cli and model ({model_path}) are available.")
+    return True
+
+
 def process_video_files(video_paths, api_key, config):
     """Process each video file: extract audio, transcribe, and save text."""
     total_files = len(video_paths)
@@ -138,7 +223,12 @@ def process_video_files(video_paths, api_key, config):
         print(f"   Audio file size: {audio_size / 1024 / 1024:.2f} MB")
 
         print("   Sending audio for transcription...")
-        transcription_result = transcribe_audio(str(audio_path), api_key, config)
+        transcription_method = config.get("transcription", {}).get("method", "assemblyai")
+        
+        if transcription_method == "whisper":
+            transcription_result = transcribe_audio_whisper(str(audio_path), config)
+        else:
+            transcription_result = transcribe_audio(str(audio_path), api_key, config)
 
         if transcription_result:
             print("   Transcription received successfully.")
@@ -178,20 +268,32 @@ def main():
         print("Error: no video paths found in the configuration.")
         return
 
-    api_key_from_env = os.environ.get("ASSEMBLYAI_API_KEY")
-    api_key_from_config = config.get("assemblyai", {}).get("api_key")
-    api_key = api_key_from_env or api_key_from_config
+    transcription_method = config.get("transcription", {}).get("method", "assemblyai")
+    print(f"Using transcription method: {transcription_method}")
 
-    if not api_key:
-        print("Error: AssemblyAI API key not provided.")
-        print("Set the API key via an environment variable:")
-        print("    export ASSEMBLYAI_API_KEY='your_api_key_here'")
-        print("or add it to the [assemblyai] section in config.toml.")
-        return
+    # Check requirements based on selected method
+    if transcription_method == "whisper":
+        if not check_whisper_requirements(config):
+            print("Error: Whisper requirements not met. Please check whisper-cli and model file.")
+            return
+        api_key = None  # Not needed for whisper
+    else:
+        # AssemblyAI method
+        api_key_from_env = os.environ.get("ASSEMBLYAI_API_KEY")
+        api_key_from_config = config.get("assemblyai", {}).get("api_key")
+        api_key = api_key_from_env or api_key_from_config
 
-    source = "environment variable" if api_key_from_env else "config file"
-    print(f"Using AssemblyAI API key from {source}.")
+        if not api_key:
+            print("Error: AssemblyAI API key not provided.")
+            print("Set the API key via an environment variable:")
+            print("    export ASSEMBLYAI_API_KEY='your_api_key_here'")
+            print("or add it to the [assemblyai] section in config.toml.")
+            return
 
+        source = "environment variable" if api_key_from_env else "config file"
+        print(f"Using AssemblyAI API key from {source}.")
+
+    # Check ffmpeg requirement
     try:
         subprocess.run(["ffmpeg", "-version"], capture_output=True, check=True)
     except (subprocess.CalledProcessError, FileNotFoundError):


### PR DESCRIPTION
## Summary
- add whisper-cli transcription path alongside AssemblyAI
- update config defaults and docs for choosing a transcription method
- ignore large whisper models by default

## Testing
- python -m compileall main.py